### PR TITLE
feat: process uploads with expo-image-manipulator

### DIFF
--- a/lib/__tests__/imageUtils.test.ts
+++ b/lib/__tests__/imageUtils.test.ts
@@ -1,0 +1,31 @@
+import * as ImageManipulator from 'expo-image-manipulator';
+import { processImageForUpload } from '../imageUtils';
+
+jest.mock('expo-image-manipulator', () => ({
+  manipulateAsync: jest.fn().mockResolvedValue({ uri: 'processed-uri' }),
+  SaveFormat: { JPEG: 'jpeg' },
+}));
+
+describe('processImageForUpload', () => {
+  beforeEach(() => {
+    (ImageManipulator.manipulateAsync as jest.Mock).mockClear();
+  });
+
+  it('resizes images when max dimensions are provided', async () => {
+    await processImageForUpload('test-uri', { maxWidth: 100, maxHeight: 200 });
+    expect(ImageManipulator.manipulateAsync).toHaveBeenCalledWith(
+      'test-uri',
+      [{ resize: { width: 100, height: 200 } }],
+      expect.objectContaining({ compress: 1 })
+    );
+  });
+
+  it('applies quality to compression', async () => {
+    await processImageForUpload('test-uri', { quality: 0.5 });
+    expect(ImageManipulator.manipulateAsync).toHaveBeenCalledWith(
+      'test-uri',
+      [],
+      expect.objectContaining({ compress: 0.5 })
+    );
+  });
+});

--- a/lib/imageUtils.ts
+++ b/lib/imageUtils.ts
@@ -1,5 +1,5 @@
 // Image processing utilities
-// TODO: Install expo-image-manipulator for image compression and resizing
+import * as ImageManipulator from 'expo-image-manipulator';
 
 interface ImageProcessOptions {
   maxWidth?: number;
@@ -11,9 +11,19 @@ export const processImageForUpload = async (
   uri: string,
   options: ImageProcessOptions = {}
 ): Promise<string> => {
-  // For now, return the original URI
-  // TODO: Implement image processing when expo-image-manipulator is installed
-  return uri;
+  const { maxWidth, maxHeight, quality } = options;
+  const actions: ImageManipulator.Action[] = [];
+
+  if (maxWidth || maxHeight) {
+    actions.push({ resize: { width: maxWidth, height: maxHeight } });
+  }
+
+  const result = await ImageManipulator.manipulateAsync(uri, actions, {
+    compress: quality ?? 1,
+    format: ImageManipulator.SaveFormat.JPEG,
+  });
+
+  return result.uri;
 };
 
 export const validateImageFile = (uri: string): boolean => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "^2.4.0",
+        "expo-image-manipulator": "~13.1.7",
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "^14.1.5",
         "expo-linking": "~7.1.7",
@@ -7234,6 +7235,18 @@
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
       "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz",
+      "integrity": "sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "react-native-web": "~0.20.0",
     "zustand": "^5.0.6",
     "expo-dev-client": "~5.2.4",
-    "expo-location": "~18.1.6"
+    "expo-location": "~18.1.6",
+    "expo-image-manipulator": "~13.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add expo-image-manipulator dependency
- resize and compress images before upload
- test image processing options

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689ea4fd64a48321b7b380cc4d4fdbe2