### PR TITLE
Replace gardener screen with questionnaire and tidy profile/login UI

### DIFF
--- a/app/_tabs/gardener.tsx
+++ b/app/_tabs/gardener.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -6,399 +6,98 @@ import {
   ScrollView,
   TouchableOpacity,
   SafeAreaView,
-  Dimensions,
-  Animated,
+  Alert,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { LiquidGlassView } from '../../components/liquid/LiquidGlassView';
+import { theme } from '../../constants/theme';
+import { Button } from '../../components/ui/Button';
 
-const { width: screenWidth } = Dimensions.get('window');
-
-interface LessonUnit {
+interface Question {
   id: string;
-  number: number;
-  title: string;
-  description: string;
-  coins: number;
-  score: number;
-  isLocked: boolean;
-  isCompleted: boolean;
-  isCurrent: boolean;
+  text: string;
+  options: string[];
 }
 
-const units: LessonUnit[] = [
+const questions: Question[] = [
   {
-    id: '1',
-    number: 1,
-    title: '1.1',
-    description: '',
-    coins: 0,
-    score: 0,
-    isLocked: false,
-    isCompleted: true,
-    isCurrent: false,
+    id: 'relationship',
+    text: 'What are you looking for?',
+    options: ['Long-term', 'Something casual', 'Friendship'],
   },
   {
-    id: '2',
-    number: 1,
-    title: '1.2',
-    description: '',
-    coins: 0,
-    score: 0,
-    isLocked: false,
-    isCompleted: false,
-    isCurrent: true,
+    id: 'personality',
+    text: 'How would friends describe you?',
+    options: ['Adventurous', 'Thoughtful', 'Spontaneous'],
   },
   {
-    id: '3',
-    number: 1,
-    title: '1.3',
-    description: '',
-    coins: 0,
-    score: 0,
-    isLocked: true,
-    isCompleted: false,
-    isCurrent: false,
+    id: 'date',
+    text: 'Ideal first date?',
+    options: ['Coffee', 'Outdoor activity', 'Dinner'],
   },
 ];
 
-const currentLesson = {
-  number: '1.2',
-  title: 'Is there a perfect person ?',
-  description: 'Will learn :',
-  coins: 3200,
-  score: 8500,
-};
-
-export default function GardenerScreen() {
+export default function QuestionnaireScreen() {
   const insets = useSafeAreaInsets();
+  const [answers, setAnswers] = useState<Record<string, string>>({});
 
-  // Animation values for header
-  const scrollY = useRef(new Animated.Value(0)).current;
-  const headerTranslateY = scrollY.interpolate({
-    inputRange: [0, 50],
-    outputRange: [0, -100],
-    extrapolate: 'clamp',
-  });
+  const selectOption = (qid: string, option: string) => {
+    setAnswers((prev) => ({ ...prev, [qid]: option }));
+  };
+
+  const handleSubmit = () => {
+    Alert.alert('Thanks!', 'Your answers have been submitted.');
+  };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Animated.ScrollView
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: insets.bottom + 100 }}
-        onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
-          useNativeDriver: true,
-        })}
-        scrollEventThrottle={16}
-      >
-        {/* Header */}
-        <Animated.View style={[styles.header, { transform: [{ translateY: headerTranslateY }] }]}>
-          <Text style={styles.headerTitle}>The</Text>
-          <Text style={styles.headerTitle}>Gardener</Text>
-          <Text style={styles.headerSubtitle}>
-            Chat with the Gardener, Practice Conversations, ...
-          </Text>
-        </Animated.View>
-
-        {/* Gardener Avatar */}
-        <View style={styles.avatarContainer}>
-          <View style={styles.avatar}>
-            <Ionicons name="person" size={60} color="#A0354E" />
-          </View>
-          <TouchableOpacity style={styles.startChatButton}>
-            <Text style={styles.startChatText}>Start Chat</Text>
-          </TouchableOpacity>
-        </View>
-
-        {/* Growth Opportunities Section */}
-        <LinearGradient colors={['#A0354E', '#8B1E2D']} style={styles.growthSection}>
-          <Text style={styles.growthTitle}>Growth</Text>
-          <Text style={styles.growthTitle}>Opportunities</Text>
-
-          {/* Unit Cards */}
-          <View style={styles.unitsRow}>
-            {units.map((unit) => (
-              <TouchableOpacity key={unit.id} style={styles.unitCard} disabled={unit.isLocked}>
-                <Text style={styles.unitLabel}>Unit {unit.number}</Text>
-                <View
-                  style={[
-                    styles.unitCircle,
-                    unit.isCompleted && styles.unitCompleted,
-                    unit.isCurrent && styles.unitCurrent,
-                    unit.isLocked && styles.unitLocked,
-                  ]}
+    <SafeAreaView style={[styles.container, { paddingBottom: insets.bottom }]}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        {questions.map((q) => (
+          <View key={q.id} style={styles.question}>
+            <Text style={styles.questionText}>{q.text}</Text>
+            {q.options.map((option) => (
+              <TouchableOpacity
+                key={option}
+                style={[styles.option, answers[q.id] === option && styles.optionSelected]}
+                onPress={() => selectOption(q.id, option)}
+              >
+                <Text
+                  style={[styles.optionText, answers[q.id] === option && styles.optionTextSelected]}
                 >
-                  {unit.isLocked ? (
-                    <Ionicons name="lock-closed" size={24} color="#666" />
-                  ) : (
-                    <Text
-                      style={[
-                        styles.unitNumber,
-                        unit.isCompleted && styles.unitNumberCompleted,
-                        unit.isCurrent && styles.unitNumberCurrent,
-                      ]}
-                    >
-                      {unit.title}
-                    </Text>
-                  )}
-                </View>
+                  {option}
+                </Text>
               </TouchableOpacity>
             ))}
           </View>
-
-          {/* Current Lesson Card with Liquid Glass */}
-          <LiquidGlassView
-            intensity={85}
-            tint="light"
-            style={styles.lessonCard}
-            borderRadius={20}
-            glassTint="rgba(255, 255, 255, 0.95)"
-          >
-            <Text style={styles.lessonNumber}>{currentLesson.number}</Text>
-            <Text style={styles.lessonTitle}>{currentLesson.title}</Text>
-            <Text style={styles.lessonDescription}>{currentLesson.description}</Text>
-
-            <View style={styles.rewardsRow}>
-              <View style={styles.rewardItem}>
-                <View style={styles.coinIcon}>
-                  <Text style={styles.coinEmoji}>🪙</Text>
-                </View>
-                <View>
-                  <Text style={styles.rewardValue}>{currentLesson.coins}</Text>
-                  <Text style={styles.rewardLabel}>Coins</Text>
-                </View>
-              </View>
-
-              <View style={styles.rewardItem}>
-                <View style={styles.starIcon}>
-                  <Text style={styles.starEmoji}>⭐</Text>
-                </View>
-                <View>
-                  <Text style={styles.rewardValue}>{currentLesson.score}</Text>
-                  <Text style={styles.rewardLabel}>Score</Text>
-                </View>
-              </View>
-            </View>
-
-            <TouchableOpacity style={styles.startButton}>
-              <Text style={styles.startButtonText}>Start</Text>
-            </TouchableOpacity>
-          </LiquidGlassView>
-
-          {/* Additional Lessons */}
-          <View style={styles.additionalLessons}>
-            <LiquidGlassView
-              intensity={80}
-              tint="light"
-              style={styles.miniLessonCard}
-              borderRadius={16}
-            >
-              <Text style={styles.miniLessonTitle}>Fun Facts</Text>
-            </LiquidGlassView>
-          </View>
-        </LinearGradient>
-      </Animated.ScrollView>
+        ))}
+        <Button title="Submit" onPress={handleSubmit} style={styles.submitButton} />
+      </ScrollView>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  additionalLessons: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
+  container: { backgroundColor: theme.colors.background, flex: 1 },
+  content: { padding: theme.spacing.lg },
+  option: {
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    marginBottom: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.md,
   },
-  avatar: {
-    alignItems: 'center',
-    backgroundColor: '#F5E6F0',
-    borderRadius: 50,
-    height: 100,
-    justifyContent: 'center',
-    marginBottom: 15,
-    width: 100,
+  optionSelected: {
+    backgroundColor: theme.colors.primaryLight,
+    borderColor: theme.colors.primary,
   },
-  avatarContainer: {
-    alignItems: 'center',
-    paddingVertical: 20,
-  },
-  coinEmoji: {
-    fontSize: 20,
-  },
-  coinIcon: {
-    alignItems: 'center',
-    backgroundColor: '#FFB901',
-    borderRadius: 20,
-    height: 40,
-    justifyContent: 'center',
-    marginRight: 10,
-    width: 40,
-  },
-  container: {
-    backgroundColor: '#FAFAFA',
-    flex: 1,
-  },
-  growthSection: {
-    borderTopLeftRadius: 30,
-    borderTopRightRadius: 30,
-    flex: 1,
-    marginTop: 20,
-    paddingHorizontal: 20,
-    paddingTop: 30,
-  },
-  growthTitle: {
-    color: 'white',
-    fontSize: 28,
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  header: {
-    alignItems: 'center',
-    paddingBottom: 10,
-    paddingTop: 20,
-  },
-  headerSubtitle: {
-    color: '#666',
-    fontSize: 14,
-    marginTop: 5,
-    paddingHorizontal: 40,
-    textAlign: 'center',
-  },
-  headerTitle: {
-    color: '#1a1a1a',
-    fontSize: 32,
-    fontWeight: 'bold',
-  },
-  lessonCard: {
-    marginBottom: 20,
-    padding: 25,
-  },
-  lessonDescription: {
-    color: '#666',
-    fontSize: 14,
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  lessonNumber: {
-    color: '#1a1a1a',
-    fontSize: 32,
-    fontWeight: 'bold',
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  lessonTitle: {
-    color: '#1a1a1a',
-    fontSize: 20,
+  optionText: { color: theme.colors.text.primary },
+  optionTextSelected: { color: theme.colors.text.inverse },
+  question: { marginBottom: theme.spacing.xl },
+  questionText: {
+    color: theme.colors.text.primary,
+    fontSize: theme.typography.fontSize.lg,
     fontWeight: '600',
-    marginBottom: 10,
-    textAlign: 'center',
+    marginBottom: theme.spacing.md,
   },
-  miniLessonCard: {
-    alignItems: 'center',
-    padding: 20,
-    width: (screenWidth - 60) / 2,
-  },
-  miniLessonTitle: {
-    color: '#1a1a1a',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  rewardItem: {
-    alignItems: 'center',
-    flexDirection: 'row',
-  },
-  rewardLabel: {
-    color: '#666',
-    fontSize: 12,
-  },
-  rewardValue: {
-    color: '#1a1a1a',
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  rewardsRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    marginBottom: 25,
-  },
-  starEmoji: {
-    fontSize: 20,
-  },
-  starIcon: {
-    alignItems: 'center',
-    backgroundColor: '#FFD700',
-    borderRadius: 20,
-    height: 40,
-    justifyContent: 'center',
-    marginRight: 10,
-    width: 40,
-  },
-  startButton: {
-    backgroundColor: '#A0354E',
-    borderRadius: 25,
-    paddingVertical: 15,
-  },
-  startButtonText: {
-    color: 'white',
-    fontSize: 18,
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  startChatButton: {
-    backgroundColor: '#A0354E',
-    borderRadius: 25,
-    paddingHorizontal: 30,
-    paddingVertical: 12,
-  },
-  startChatText: {
-    color: 'white',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  unitCard: {
-    alignItems: 'center',
-    backgroundColor: 'rgba(255, 255, 255, 0.15)',
-    borderRadius: 16,
-    padding: 15,
-    width: (screenWidth - 60) / 3,
-  },
-  unitCircle: {
-    alignItems: 'center',
-    backgroundColor: 'rgba(255, 255, 255, 0.3)',
-    borderRadius: 25,
-    height: 50,
-    justifyContent: 'center',
-    width: 50,
-  },
-  unitCompleted: {
-    backgroundColor: '#34C759',
-  },
-  unitCurrent: {
-    backgroundColor: '#FF3B5C',
-  },
-  unitLabel: {
-    color: 'white',
-    fontSize: 12,
-    marginBottom: 8,
-  },
-  unitLocked: {
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-  },
-  unitNumber: {
-    color: 'white',
-    fontSize: 16,
-    fontWeight: 'bold',
-  },
-  unitNumberCompleted: {
-    color: 'white',
-  },
-  unitNumberCurrent: {
-    color: 'white',
-  },
-  unitsRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    marginBottom: 25,
-    marginTop: 25,
-  },
+  submitButton: { marginTop: theme.spacing.lg },
 });

--- a/app/_tabs/two.tsx
+++ b/app/_tabs/two.tsx
@@ -232,24 +232,25 @@ export default function ProfileScreen() {
           <Text style={styles.sectionTitle}>My Photos</Text>
           <View style={styles.photosGrid}>
             {additionalPhotos.map((photo, index) => (
-              <TouchableOpacity
-                key={index + 1}
-                style={[styles.photoSlot, photo && styles.filledSlot]}
-                onPress={() => isEditing && pickImage(index + 1)}
-                disabled={!isEditing}
-              >
-                {photo ? (
-                  <OptimizedImage
-                    source={{ uri: photo }}
-                    style={styles.photo}
-                    showLoadingIndicator={true}
-                  />
-                ) : (
-                  <View style={styles.emptyPhoto}>
-                    <Ionicons name="add" size={28} color={theme.colors.primary} />
-                  </View>
-                )}
-              </TouchableOpacity>
+              <View key={index + 1} style={styles.photoContainer}>
+                <TouchableOpacity
+                  style={[styles.photoSlot, photo && styles.filledSlot]}
+                  onPress={() => isEditing && pickImage(index + 1)}
+                  disabled={!isEditing}
+                >
+                  {photo ? (
+                    <OptimizedImage
+                      source={{ uri: photo }}
+                      style={styles.photo}
+                      showLoadingIndicator={true}
+                    />
+                  ) : (
+                    <View style={styles.emptyPhoto}>
+                      <Ionicons name="add" size={28} color={theme.colors.primary} />
+                    </View>
+                  )}
+                </TouchableOpacity>
+              </View>
             ))}
           </View>
         </LiquidGlassView>
@@ -441,18 +442,20 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
   },
+  photoContainer: {
+    padding: 4,
+    width: '33.333%',
+  },
   photoSlot: {
     aspectRatio: 1,
     backgroundColor: '#F8F8F8',
     borderRadius: 12,
-    marginBottom: 10,
     overflow: 'hidden',
-    width: '31%',
   },
   photosGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'space-between',
+    marginHorizontal: -4,
   },
   photosSection: {
     marginBottom: 16,

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -260,6 +260,7 @@ export default function LoginScreen() {
               onPress={() => setIsLogin(!isLogin)}
               variant="ghost"
               style={styles.switchButton}
+              textStyle={styles.switchButtonText}
             />
 
             {/* Test Mode Button - Only in development */}
@@ -369,6 +370,9 @@ const styles = StyleSheet.create({
   },
   switchButton: {
     marginBottom: theme.spacing.md,
+  },
+  switchButtonText: {
+    color: theme.colors.primary,
   },
   testButton: {
     marginBottom: theme.spacing.md,


### PR DESCRIPTION
## Summary
- Replace "The Gardener" tab with a simple onboarding questionnaire
- Fix profile screen photo grid alignment
- Ensure login/signup toggle button text remains visible

## Testing
- `CI=true npm test` *(no tests found?)*
- `npm run lint` *(warning: unsupported TypeScript version)*
- `npm run type-check` *(no output, exited)*

------
https://chatgpt.com/codex/tasks/task_e_68a02b51bf448321a0d1f0a1471c1c00